### PR TITLE
fix download link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
 	<div class="collapse navbar-collapse" id="navbarSupportedContent">
 		<ul class="navbar-nav mr-auto">
 			<li class="nav-item">
-				<a class="nav-link" lang="en" href="https://software.opensuse.org/">Download</a>
+				<a class="nav-link" lang="en" href="http://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-x86_64-Current">Download</a>
 			</li>
 			<li class="nav-item">
 				<a class="nav-link" lang="en" href="https://software.opensuse.org/search">Software</a>


### PR DESCRIPTION
link to the direct download
besides this, software.opensuse.org is linked 2 times

Signed-off-by: Maximilian Meister <mmeister@suse.de>