### PR TITLE
Fix line-break of contribution link in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -47,7 +47,8 @@
 
       <div class="row">
         <div class="col-md-6">
-          © 2011–2018 openSUSE contributors. License: <a href=https://www.gnu.org/licenses/fdl.txt>GNU FDL v1.3 or later</a>. Visit <a href=https://github.com/kubic-project/kubic-o-o> to provide enhancements or open issues about this page.
+          Visit <a href=https://github.com/kubic-project/kubic-o-o> to provide enhancements or open issues about this page.</a><br>
+          © 2011–2018 openSUSE contributors. License: <a href=https://www.gnu.org/licenses/fdl.txt>GNU FDL v1.3 or later</a>.
         </div>
       </div>
   </div>


### PR DESCRIPTION
Now tested locally with jekyll and proper CSS theme :)

![screenshot_20180924_151355](https://user-images.githubusercontent.com/1693432/45954178-9cf14c00-c00c-11e8-95bc-625ce8bafd0e.png)
