### PR TITLE
header: Change the Wiki link to Portal:Kubic

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,7 +17,7 @@
 				<a class="nav-link" lang="en" href="https://doc.opensuse.org/">Documentation</a>
 			</li>
 			<li class="nav-item">
-				<a class="nav-link" lang="en" href="https://en.opensuse.org/">Wiki</a>
+				<a class="nav-link" lang="en" href="https://en.opensuse.org/Portal:Kubic">Wiki</a>
 			</li>
 			<li class="nav-item">
 				<a class="nav-link" lang="en" href="https://forums.opensuse.org/">Forums</a>


### PR DESCRIPTION
Portal:Kubic is the main site on openSUSE Wiki which aims to gather
all information related to Kubic, Kubernetes and containers in
openSUSE.