### PR TITLE
Lets keep the menu always visible

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-<nav id="global-navbar" class="navbar navbar-expand-sm navbar-dark bg-dark">
+<nav id="global-navbar" class="navbar navbar-expand-sm navbar-dark bg-dark sticky-top">
 	<button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
 		<span class="navbar-toggler-icon"></span>
 	</button>


### PR DESCRIPTION
Scrolling whole pages just for a menu is no fun.

Before:

![image](https://user-images.githubusercontent.com/74432/81095825-d3d85500-8f05-11ea-8873-5f98af8988d9.png)

After:

![image](https://user-images.githubusercontent.com/74432/81095869-e488cb00-8f05-11ea-85d9-7f0608d1d05e.png)
